### PR TITLE
Use `defines` object values for AMD parameter names

### DIFF
--- a/tasks/encasor.js
+++ b/tasks/encasor.js
@@ -70,7 +70,7 @@ exports.encase = function (content, options) {
 				return 'define([' + names.map(function (name, i) {
 					return "'" + name + "'";
 				}).join(', ') + '], function(' + names.map(function (name) {
-					return name;
+					return defines[name];
 				}).join(', ') + ') {\n';
 			})(defines);
 

--- a/test/dest/amd-browser-export.js
+++ b/test/dest/amd-browser-export.js
@@ -1,4 +1,4 @@
-define(['jquery', 'backbone'], function(jquery, backbone) {
+define(['jquery', 'backbone'], function($, bb) {
 'use strict';
 var hoge = 100,
 	piyo = 200,

--- a/test/dest/amd-browser-multiexport.js
+++ b/test/dest/amd-browser-multiexport.js
@@ -1,4 +1,4 @@
-define(['jquery', 'backbone', 'exports'], function(jquery, backbone, exports) {
+define(['jquery', 'backbone', 'exports'], function($, bb, exports) {
 'use strict';
 var hoge = 100,
 	piyo = 200,

--- a/test/dest/amd-browser-with-banner.js
+++ b/test/dest/amd-browser-with-banner.js
@@ -1,6 +1,6 @@
 /* amd-browser-test */
 
-define(['jquery', 'backbone', 'exports'], function(jquery, backbone, exports) {
+define(['jquery', 'backbone', 'exports'], function($, bb, exports) {
 
 var hoge = 100,
 	piyo = 200,

--- a/test/dest/amd-browser.js
+++ b/test/dest/amd-browser.js
@@ -1,4 +1,4 @@
-define(['jquery', 'backbone', 'exports'], function(jquery, backbone, exports) {
+define(['jquery', 'backbone', 'exports'], function($, bb, exports) {
 'use strict';
 var hoge = 100,
 	piyo = 200,


### PR DESCRIPTION
README.md explains that the `defines` option should be an object/hash, but until now only the hash _key_ has been used. This PR changes that behavior to use keys as module names and values as parameter names; e.g.:

```
defines: {
  "jquery": "$",
  "backbone": "bb"
}
=> define(['jquery', 'backbone'], function($, bb) {
```

This is important because it allows us to to add dependencies that are kept inside a tree e.g. `define(['foo/bar'], function (foo) {...` which would otherwise be rendered `define(['foo/bar'], function (foo/bar) {...`
